### PR TITLE
Adding Waggle, A2A agent search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ New to A2A? Here's a suggested path:
 This section aims to list standalone tools and utilities related to the A2A protocol. The ecosystem is still developing, and community contributions are welcome!
 
 *   **Agent Discovery Services**
+    *   🔍 [Waggle](https://waggle.zone) by [@enmerk4r](https://github.com/enmerk4r) ([Source](https://github.com/enmerk4r/agentsearch)) - A semantic search engine for A2A agents. Automatically discovers and indexes agents from registries, GitHub, and the web, with health monitoring, uptime tracking, and an A2A-compliant meta-agent interface for agent-to-agent discovery.
     *   Some platform-level implementations (like [Aira](https://github.com/IhateCreatingUserNames2/Aira)) include agent registration and discovery mechanisms within their features.
-    *   *Community contributions welcome: Standalone agent directory service implementations, Agent Card search engines, etc.* <!-- TODO: Community contributions for related tools are welcome -->
 *   **A2A Validation Tool**
     *   ⚙️ [a2a-inspector](https://github.com/a2aproject/a2a-inspector) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-inspector?style=social)](https://github.com/a2aproject/a2a-inspector) - **Official** validation tools for A2A agents, including compliance checking and debugging utilities.
     *   ⚙️ [A2A Validation Tool](https://github.com/llmx-de/a2a-validation-tool) by [@llmx-de](https://github.com/llmx-de) [![Stars](https://img.shields.io/github/stars/llmx-de/a2a-validation-tool?style=social)](https://github.com/llmx-de/a2a-validation-tool) - Cross-platform desktop app for testing & validating A2A protocol implementations, with features like multi-agent connection and session management.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ New to A2A? Here's a suggested path:
 This section aims to list standalone tools and utilities related to the A2A protocol. The ecosystem is still developing, and community contributions are welcome!
 
 *   **Agent Discovery Services**
-    *   🔍 [Waggle](https://waggle.zone) by [@enmerk4r](https://github.com/enmerk4r) ([Source](https://github.com/enmerk4r/agentsearch)) - A semantic search engine for A2A agents. Automatically discovers and indexes agents from registries, GitHub, and the web, with health monitoring, uptime tracking, and an A2A-compliant meta-agent interface for agent-to-agent discovery.
+    *   🔍 [Waggle](https://waggle.zone) by [@enmerk4r](https://github.com/enmerk4r) - A semantic search engine for A2A agents. Automatically discovers and indexes agents from registries, GitHub, and the web, with health monitoring, uptime tracking, and an A2A-compliant meta-agent interface for agent-to-agent discovery.
     *   Some platform-level implementations (like [Aira](https://github.com/IhateCreatingUserNames2/Aira)) include agent registration and discovery mechanisms within their features.
 *   **A2A Validation Tool**
     *   ⚙️ [a2a-inspector](https://github.com/a2aproject/a2a-inspector) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-inspector?style=social)](https://github.com/a2aproject/a2a-inspector) - **Official** validation tools for A2A agents, including compliance checking and debugging utilities.


### PR DESCRIPTION
Hi there!

I developed [Waggle](https://waggle.zone/), which is a search engine that indexes public A2A endpoints and allows users to easily find relevant agents via semantic search. Waggle has a number of cool features:

- It does automatic health monitoring for each agent to make sure they are currently up and ready to accept requests. Agents that are down are hidden by default.
- Agents are indexed automatically, but users can also register their own agents or claim ownership of an agent that's already been indexed. I have a cryptographic way of verifying agent ownership.
- Waggle has its own A2A-compliant search agent at `https://api.waggle.zone/.well-known/agent.json`. It allows A2A agents to find each other.
- Waggle also has a REST API and a Claude Code Skill, so there are plenty of ways to search for A2A agents programmatically.

I do ask folks to register and generate a free API key to monitor usage and prevent abuse, but otherwise, Waggle is free. 

Thanks for maintaining this list — it's been a great resource for navigating the A2A ecosystem. Happy to adjust the entry if you'd prefer different formatting or placement!