### PR TITLE
Add AnyBrowse - Web Browsing Agent with A2A + x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ New to A2A? Here's a suggested path:
 *   🌟 [n8n-nodes-agent2agent](https://github.com/pjawz/n8n-nodes-agent2agent) by [@pjawz](https://github.com/pjawz) [![Stars](https://img.shields.io/github/stars/pjawz/n8n-nodes-agent2agent?style=social)](https://github.com/pjawz/n8n-nodes-agent2agent) - Adds nodes to n8n for interacting with AI agents using Google's Agent2Agent (A2A) protocol.
 *   🌟 [google-calendar-agent](https://github.com/inference-gateway/google-calendar-agent) by [@inference-gateway](https://github.com/inference-gateway) [![Stars](https://img.shields.io/github/stars/inference-gateway/google-calendar-agent?style=social)](https://github.com/inference-gateway/google-calendar-agent) - A standalone A2A agent that can manage a user's Google Calendar, compatible with any OpenAI-compatible API for its LLM.
 *   🌟 [A2AApp](https://github.com/tanaikech/A2AApp) by [@tanaikech](https://github.com/tanaikech) [![Stars](https://img.shields.io/github/stars/tanaikech/A2AApp?style=social)](https://github.com/tanaikech/A2AApp) - An Agent2Agent (A2A) network built with Google Apps Script, enabling secure, decentralized AI communication and integration within Google Workspace as both an A2A server and client.
+*   🌐 [AnyBrowse](https://anybrowse.dev) - Autonomous web browsing agent that converts URLs to LLM-ready Markdown via real Chrome browsers, with A2A protocol support and x402 micropayments on Base.
 <!-- Add yours here! See CONTRIBUTING.md -->
 
 ## 🛠️ Tools & Utilities


### PR DESCRIPTION
## Summary

- Adds [AnyBrowse](https://anybrowse.dev) to the **Platforms & Integrated Solutions** section
- AnyBrowse is an autonomous web browsing agent that converts any URL to clean, LLM-ready Markdown via real Chrome browsers
- Supports A2A protocol with x402 micropayments in USDC on Base
- Agent Card: https://anybrowse.dev/.well-known/agent-card.json
- Three skills: scrape, crawl, search