### PR TITLE
Add Agent Readiness Kit to Other Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 *   **Other Utilities**
     *   *Community contributions welcome: e.g., A2A message construction helper tools, Agent Card generators, Mock A2A Server/Client, etc.* <!-- TODO: Community contributions for related tools are welcome -->
     *   🌟 [autoa2a](https://github.com/NapthaAI/autoa2a) by [NapthaAI](https://github.com/NapthaAI) [![Stars](https://img.shields.io/github/stars/NapthaAI/autoa2a?style=social)](https://github.com/NapthaAI/autoa2a) - Easily convert agents and orchestrators from existing agent frameworks to A2A servers.
+    *   📋 [Agent Readiness Kit](https://github.com/trssantos/agent-readiness-kit) by [@trssantos](https://github.com/trssantos) [![Stars](https://img.shields.io/github/stars/trssantos/agent-readiness-kit?style=social)](https://github.com/trssantos/agent-readiness-kit) - Fill-in-the-blank templates for agent-card.json, llms.txt, AGENTS.md, robots.txt AI directives, and JSON-LD structured data, with a step-by-step deployment guide and 20-point readiness checklist.
 
 ## 📚 Tutorials & Articles
 


### PR DESCRIPTION
Adds the [Agent Readiness Kit](https://github.com/trssantos/agent-readiness-kit) to the **Other Utilities** section under Tools & Utilities.

## What it is

A set of fill-in-the-blank templates for making products agent-discoverable:
- **agent-card.json** — A2A Protocol compliant template with inline instructions
- **llms.txt** — AI-readable product description template
- **AGENTS.md** — Agent capability description template
- **robots.txt** — AI crawler directives (GPTBot, ClaudeBot, etc.)
- **JSON-LD structured data** — Organization, SoftwareApplication, Product, FAQPage schemas
- **Step-by-step deployment guide** with platform-specific instructions
- **20-point readiness checklist** with scoring

## Why it fits

The "Other Utilities" section explicitly calls for "Agent Card generators" as a welcome community contribution. This kit provides ready-to-use agent-card.json templates with detailed instructions, alongside the broader agent discoverability package.

## Checklist
- [x] Resource is directly relevant to A2A protocol
- [x] Links are working
- [x] Description is concise and objective
- [x] Follows existing formatting patterns