### PR TITLE
Add Lingua Universale to Related Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 ## 🔗 Related Protocols & Concepts
 
 *   📦 [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/servers) - Complementary protocol focused on providing tools/context *to* agents. ([A2A and MCP Discussion](https://a2aproject.github.io/A2A/#/topics/a2a_and_mcp.md)).
+*   🔍 [Lingua Universale](https://github.com/rafapra3008/cervellaswarm) by [@rafapra3008](https://github.com/rafapra3008) - Formal verification DSL for AI agent protocols using multiparty session types. Complementary to A2A: verify message sequence correctness at spec time. ([PyPI](https://pypi.org/project/cervellaswarm-lingua-universale/)).
 *   📞 *Function Calling / Tool Use Standards* - *Community contributions welcome: Discussion on patterns, best practices, or relevant standards for function calling/tool use in conjunction with A2A.* <!-- TODO: Community contributions for related standards or discussions are welcome -->
 
 ## 💬 Community


### PR DESCRIPTION
## What

Adds [Lingua Universale](https://github.com/rafapra3008/cervellaswarm) to the **Related Protocols & Concepts** section.

## Why

Lingua Universale is a formal verification DSL for AI agent communication protocols using multiparty session types (Honda/Yoshida, POPL 2008). It's complementary to A2A — while A2A defines *how* agents communicate, LU verifies that message sequences are *correct* at specification time (deadlock-free, role-complete, type-safe).

- **3,867+ tests**, zero external dependencies, pure Python stdlib
- Compiler, linter, formatter, LSP, CLI, REPL, VS Code extension, MCP server
- Available on [PyPI](https://pypi.org/project/cervellaswarm-lingua-universale/)

## Checklist

- [x] Entry added in alphabetical order
- [x] Follows existing format
- [x] Link is valid and public