### PR TITLE
Add Swift SDK (a2a-swift) to SDKs & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ New to A2A? Here's a suggested path:
     *   🌟 [a2a-java](https://github.com/a2aproject/a2a-java) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-java?style=social)](https://github.com/a2aproject/a2a-java) - **Official** Java SDK for the Agent2Agent (A2A) Protocol.
     *   🌟 [a2ajava](https://github.com/vishalmysore/a2ajava) by [@vishalmysore](https://github.com/vishalmysore) [![Stars](https://img.shields.io/github/stars/vishalmysore/a2ajava?style=social)](https://github.com/vishalmysore/a2ajava) - Java A2A server/client implementation using Spring Boot with annotations. Supports WebSockets, MCP integration, and includes enterprise/Kubernetes deployment tutorials.
     *   🌟 [a2a4j](https://github.com/a2ap/a2a4j) by [@a2ap](https://github.com/a2ap) [![Stars](https://img.shields.io/github/stars/a2ap/a2a4j?style=social)](https://github.com/a2ap/a2a4j) - A2A4J is a comprehensive Java implementation of the Agent2Agent Protocol, including server, client, examples, and a starter — ready to use out of the box.
+*   **Swift**
+    *   🌟 [a2a-swift](https://github.com/Victory-Apps/a2a-swift) by [@Victory-Apps](https://github.com/Victory-Apps) [![Stars](https://img.shields.io/github/stars/Victory-Apps/a2a-swift?style=social)](https://github.com/Victory-Apps/a2a-swift) - A Swift SDK for A2A with full v1.0 data model, JSON-RPC routing, SSE streaming with reconnection, Vapor integration, and testing utilities. Supports macOS, Linux, iOS, tvOS, watchOS.
 
 ##### Frameworks
 


### PR DESCRIPTION
## Summary

Adds **[a2a-swift](https://github.com/Victory-Apps/a2a-swift)** as the first Swift entry under **SDKs & Libraries (by language)**.

### About a2a-swift
- Full A2A v1.0 data model (Task, Message, Part, Artifact, AgentCard)
- JSON-RPC 2.0 routing with SSE streaming and reconnection
- Vapor web framework integration (`A2AVapor` target)
- Testing utilities with mocks and fixture builders (`A2ATesting` target)
- Supports macOS, Linux, iOS, tvOS, watchOS
- CI on GitHub Actions across all platforms