### PR TITLE
Add Global Chat to Agent Discovery Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 
 *   **Agent Discovery Services**
     *   Some platform-level implementations (like [Aira](https://github.com/IhateCreatingUserNames2/Aira)) include agent registration and discovery mechanisms within their features.
+    *   🌟 [Global Chat](https://github.com/pumanitro/global-chat) by [@pumanitro](https://github.com/pumanitro) [![Stars](https://img.shields.io/github/stars/pumanitro/global-chat?style=social)](https://github.com/pumanitro/global-chat) - Cross-protocol agent discovery platform that aggregates agents across A2A, MCP, agents.txt, and 6+ other protocols. Searchable directory with protocol comparison and an MCP server for programmatic access.
     *   *Community contributions welcome: Standalone agent directory service implementations, Agent Card search engines, etc.* <!-- TODO: Community contributions for related tools are welcome -->
 *   **A2A Validation Tool**
     *   ⚙️ [a2a-inspector](https://github.com/a2aproject/a2a-inspector) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-inspector?style=social)](https://github.com/a2aproject/a2a-inspector) - **Official** validation tools for A2A agents, including compliance checking and debugging utilities.


### PR DESCRIPTION
## What is Global Chat?

[Global Chat](https://global-chat.io) is a cross-protocol agent discovery platform that aggregates AI agents across A2A, MCP, agents.txt, and 6+ other discovery protocols. It provides a searchable directory with protocol comparison and an MCP server for programmatic access.

## Why it fits

The Tools & Utilities > Agent Discovery Services section explicitly welcomes "standalone agent directory service implementations" and "Agent Card search engines." Global Chat is exactly this — a cross-protocol discovery layer that includes A2A agent discovery alongside other protocols.

## Key features relevant to A2A

- Indexes A2A agents alongside MCP, agents.txt, ACDP, ANP, and other protocol agents
- Protocol comparison page showing how A2A fits in the broader agent discovery landscape
- Open source (GitHub: [pumanitro/global-chat](https://github.com/pumanitro/global-chat))
- MCP server available via npm (`@global-chat/mcp-server`) for programmatic agent search

## Placement

Added to **Tools & Utilities > Agent Discovery Services**, between the existing Aira entry and the community contributions note.