### PR TITLE
Add Global Chat — cross-protocol agent discovery platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 
 *   **Agent Discovery Services**
     *   Some platform-level implementations (like [Aira](https://github.com/IhateCreatingUserNames2/Aira)) include agent registration and discovery mechanisms within their features.
+    *   🔍 [Global Chat](https://global-chat.io) by [@nicobailon](https://github.com/nicobailon) [![Stars](https://img.shields.io/github/stars/nicobailon/global-chat?style=social)](https://github.com/nicobailon/global-chat) - Cross-protocol agent discovery platform that aggregates agents across A2A, MCP, agents.txt, and 10+ other protocols. Searchable directory of 100K+ agents across 15+ registries with an MCP server for programmatic access.
     *   *Community contributions welcome: Standalone agent directory service implementations, Agent Card search engines, etc.* <!-- TODO: Community contributions for related tools are welcome -->
 *   **A2A Validation Tool**
     *   ⚙️ [a2a-inspector](https://github.com/a2aproject/a2a-inspector) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-inspector?style=social)](https://github.com/a2aproject/a2a-inspector) - **Official** validation tools for A2A agents, including compliance checking and debugging utilities.


### PR DESCRIPTION
## What is this?

Adds [Global Chat](https://global-chat.io) to the **Agent Discovery Services** section under Tools & Utilities — filling the community contribution placeholder for "Standalone agent directory service implementations, Agent Card search engines."

## Why it fits

Global Chat is a cross-protocol agent discovery platform that aggregates agents across **A2A, MCP, agents.txt, ACDP**, and 10+ other protocols. It provides:

- Searchable directory of 100K+ agents across 15+ registries
- Coverage of A2A alongside MCP and other agent protocols
- An MCP server ([`@global-chat/mcp-server`](https://www.npmjs.com/package/@global-chat/mcp-server)) for programmatic access
- Free agents.txt validator

## Links

- **Website**: https://global-chat.io
- **GitHub**: https://github.com/nicobailon/global-chat
- **npm**: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)

## Checklist

- [x] Resource is directly related to A2A protocol (agent discovery across A2A and other protocols)
- [x] Link is working and repository is active
- [x] Description is clear and concise
- [x] Placed in the most relevant section (Agent Discovery Services)
- [x] Follows existing formatting conventions