### PR TITLE
Add Hashgraph Online (HOL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 
 *   📦 [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/servers) - Complementary protocol focused on providing tools/context *to* agents. ([A2A and MCP Discussion](https://a2aproject.github.io/A2A/#/topics/a2a_and_mcp.md)).
 *   📞 *Function Calling / Tool Use Standards* - *Community contributions welcome: Discussion on patterns, best practices, or relevant standards for function calling/tool use in conjunction with A2A.* <!-- TODO: Community contributions for related standards or discussions are welcome -->
+- [Hashgraph Online (HOL)](https://hol.org) - Universal agentic registry on Hedera Hashgraph with HCS-14 UAIDs. Bridges to A2A, ERC-8004, Virtuals, and x402 protocols.
 
 ## 💬 Community
 


### PR DESCRIPTION
Adds Hashgraph Online (HOL) - Universal agentic registry for AI agents

- Universal Agent IDs (UAIDs)
- Bridges to ERC-8004, A2A, Virtuals, x402
- 187K+ verified agents