### PR TITLE
Add Global Chat to Agent Discovery Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This section aims to list standalone tools and utilities related to the A2A prot
 
 *   **Agent Discovery Services**
     *   Some platform-level implementations (like [Aira](https://github.com/IhateCreatingUserNames2/Aira)) include agent registration and discovery mechanisms within their features.
+    *   🔍 [Global Chat](https://global-chat.io) by [@pumanitro](https://github.com/pumanitro) [![Stars](https://img.shields.io/github/stars/pumanitro/global-chat?style=social)](https://github.com/pumanitro/global-chat) - Cross-protocol AI agent discovery platform. Searchable directory of 100K+ agents across A2A, MCP, agents.txt, and 10+ other protocols. Includes a free agents.txt validator and an MCP server ([`@global-chat/mcp-server`](https://www.npmjs.com/package/@global-chat/mcp-server)) for programmatic access.
     *   *Community contributions welcome: Standalone agent directory service implementations, Agent Card search engines, etc.* <!-- TODO: Community contributions for related tools are welcome -->
 *   **A2A Validation Tool**
     *   ⚙️ [a2a-inspector](https://github.com/a2aproject/a2a-inspector) by [@a2aproject](https://github.com/a2aproject) [![Stars](https://img.shields.io/github/stars/a2aproject/a2a-inspector?style=social)](https://github.com/a2aproject/a2a-inspector) - **Official** validation tools for A2A agents, including compliance checking and debugging utilities.


### PR DESCRIPTION
Hey there -- adding [Global Chat](https://global-chat.io) to the **Agent Discovery Services** section under Tools & Utilities.

Global Chat is a cross-protocol agent discovery platform. It aggregates 100K+ agents from A2A, MCP, agents.txt, ACDP, and other registries into a single searchable directory. It also ships an agents.txt validator and an MCP server (`@global-chat/mcp-server` on npm) for programmatic lookups.

Relevant to awesome-a2a because:
- A2A agent cards are indexed alongside other protocol formats
- Helps developers find A2A-compatible agents across fragmented registries
- Fits the "standalone agent directory service" call-out in the Agent Discovery Services section

GitHub repo: https://github.com/pumanitro/global-chat
Live site: https://global-chat.io
npm package: https://www.npmjs.com/package/@global-chat/mcp-server

Happy to adjust the description or placement if needed. Thanks for maintaining this list!